### PR TITLE
minsar_env.yml: environment for minsar, sarvey, insarmaps_scripts

### DIFF
--- a/minsar_env.yml
+++ b/minsar_env.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.10
   - isce2     # [linux]
-  - gdal
+  - gdal=3.6*
   - mintpy
   - sardem
   - numpy<2.0
@@ -57,6 +57,15 @@ dependencies:
   - postgresql
   - psycopg2
   - pycurl
+# Sarvey
+  - PySide6
+  - cmcrameri
+  - gstools
+  - numba
+  - pymaxflow              # for sarvey: Linux only, insert '#' on Mac
+# VSM
+  - corner
+  - emcee
 # Precip
   - paramiko
 # Pip
@@ -68,4 +77,6 @@ dependencies:
       - fuzzywuzzy          # Precip
       - jupyter-ai          #
       - geocoder            # insarmaps_sccripts
+      - kamui               #
+      #- pymaxflow          # for sarvey: Mac only,  '#' will be removed on Mac
 #      - requests>=2.20.0    # sardem

--- a/setup/install_minsar.bash
+++ b/setup/install_minsar.bash
@@ -17,13 +17,25 @@ git clone git@github.com:geodesymiami/precip tools/Precip
 git clone git@github.com:geodesymiami/precip_web tools/Precip_web
 git clone git@github.com:geodesymiami/precip_cron tools/Precip_cron
 git clone git@github.com:scottstanie/sardem tools/sardem
+git clone git@github.com:luhipi/sarvey tools/sarvey
+git clone git@github.com:falkamelung/sarplotter-main.git tools/sarplotter-main
 #git clone git@github.com:geodesymiami/SourceInversion.git tools/SourceInversion
 
 ### Install code into minsar environment  #################
-if [[ "$(uname)" == "Darwin" ]]; then sed -i '' '/isce/ s/^/# /' minsar_env.yml; fi
-if [[ "$(uname)" == "Darwin" ]]; then sed -i '' '/gdal$/ s/gdal$/gdal=3.6\*/' minsar_env.yml; fi
+if [[ "$(uname)" == "Darwin" ]]; then
+    cp minsar_env.yml minsar_env_macOS.yml
+    sed -i '' '/- isce/ s/^/# /' minsar_env_macOS.yml
+    sed -i '' '/gdal$/ s/gdal$/gdal=3.6\*/' minsar_env_macOS.yml
+    sed -i '' '/- pymaxflow/ s/^/# /' minsar_env_macOS.yml                        # out-comment conda pymaxflow installation
+    sed -i '' '/#- pymaxflow/ s/#- pymaxflow/- pymaxflow/' minsar_env_macOS.yml   # activate pip pymaxflow installation
+fi
 
-tools/miniforge3/bin/mamba --verbose env create -f minsar_env.yml --yes
+
+if [[ "$(uname)" == "Linux" ]]; then
+  tools/miniforge3/bin/mamba --verbose env create -f minsar_env.yml --yes
+elif [[ "$(uname)" == "Darwin" ]]; then
+  tools/miniforge3/bin/mamba --verbose env create -f minsar_env_macOS.yml --yes
+fi
 
 source tools/miniforge3/etc/profile.d/conda.sh
 set +u         # needed for circleCI
@@ -32,6 +44,7 @@ conda activate minsar
 pip install -e tools/MintPy
 pip install -e tools/MiaplPy
 pip install -e tools/sardem
+pip install -e tools/sarvey[dev] --no-deps
 
 ###  Reduce miniforge3 directory size #################
 rm -rf tools/miniforge3/pkgs


### PR DESCRIPTION
This PR creates a unified environment for all minsar packages

## Summary by Sourcery

Create a unified, cross-platform conda environment for all minsar packages by consolidating dependencies into minsar_env.yml, adding macOS-specific adjustments, and updating the install script to clone and install sarvey and related tools

New Features:
- Clone and install sarvey and sarplotter tools in the setup script
- Include sarvey[dev] in the unified conda environment

Enhancements:
- Generate a macOS-specific env file with tailored dependency adjustments (isce, gdal, pymaxflow)
- Branch mamba environment creation for Linux and macOS in the install script
- Pin gdal to version 3.6* and expand minsar_env.yml with dependencies for sarvey (PySide6, cmcrameri, gstools, numba), VSM, and insarmaps_scripts (kamui)